### PR TITLE
Fix nodes internal ip

### DIFF
--- a/exercises/scripts/control-plane.sh
+++ b/exercises/scripts/control-plane.sh
@@ -5,12 +5,19 @@ API_ADV_ADDRESS=$2
 
 kubeadm init --pod-network-cidr $POD_CIDR --apiserver-advertise-address $API_ADV_ADDRESS | tee /vagrant/kubeadm-init.out
 
+echo "KUBELET_EXTRA_ARGS=--node-ip=$API_ADV_ADDRESS --cgroup-driver=systemd" > /etc/default/kubelet
+systemctl restart kubelet
+
 mkdir -p /home/vagrant/.kube
 cp -i /etc/kubernetes/admin.conf /home/vagrant/.kube/config
 chown vagrant:vagrant /home/vagrant/.kube/config
 mkdir -p /root/.kube
 cp -i /etc/kubernetes/admin.conf /root/.kube/config
 
-kubectl apply -f https://docs.projectcalico.org/v3.22/manifests/calico.yaml
+kubectl create -f https://projectcalico.docs.tigera.io/manifests/tigera-operator.yaml
+wget https://projectcalico.docs.tigera.io/manifests/custom-resources.yaml
+sed -i 's~cidr: 192\.168\.0\.0/16~cidr: 172\.18\.0\.0/16~g' custom-resources.yaml
+kubectl create -f custom-resources.yaml
+rm custom-resources.yaml
 
 cp /etc/kubernetes/admin.conf /vagrant/admin.conf

--- a/exercises/scripts/worker.sh
+++ b/exercises/scripts/worker.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 
 NODE=$1
-NODE_HOST_IP=20+$NODE
+NODE_HOST_IP="192.168.56.$((20+$NODE))"
 
 $(cat /vagrant/kubeadm-init.out | grep -A 2 "kubeadm join" | sed -e 's/^[ \t]*//' | tr '\n' ' ' | sed -e 's/ \\ / /g')
+
+echo "KUBELET_EXTRA_ARGS=--node-ip=$NODE_HOST_IP --cgroup-driver=systemd" > /etc/default/kubelet
+systemctl restart kubelet
 
 cp /vagrant/admin.conf /etc/kubernetes/admin.conf
 chmod ugo+r /etc/kubernetes/admin.conf


### PR DESCRIPTION
Calico has removed its manifest from the previous used url. So switching to their new way for CNI install.

And I added `KUBELET_EXTRA_ARGS` specifying node-ip and systemd cgroup driver.

Information from : https://github.com/r0mdau/ansible-kubernetes/blob/main/kubernetes-setup/common-playbook.yml#L98

Follow #2 