### PR TITLE
Add CKA self-study course and debugging github repo to README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,5 @@ All [exercises](./exercises) are numbered and live in dedicated directories star
 * 🧪 [Killer Shell: CKA Simulator](https://killer.sh/cka)
 * 🧪 [KillerCoda: CKA Scenarios](https://killercoda.com/cka)
 * 🧪 [Study4Exam: Certified Kubernetes Administrator Exam](https://www.study4exam.com/linux-foundation/info/cka)
+* 🧪 [RX-M: CKA Self-Study Course](https://rx-m.com/cka-online-training/)
+* 🧪 [Kubernetes debugging/troubleshooting scenarios](https://github.com/RX-M/bust-a-kube)


### PR DESCRIPTION
This commit adds two entries to the README under "Additional Resources":

- link to a free CKA web-based self-study course
- link to an open source debugging/troubleshooting github repo named bust-a-kube

Since the CKA is heavily weighted on troubleshooting (30%) the troubleshooting scenarios in the bust-a-kube repo should help candidates improve their debugging skills.