### PR TITLE
Fix O'Reilly interactive lab links and titles

### DIFF
--- a/exercises/01-install-cluster/instructions.md
+++ b/exercises/01-install-cluster/instructions.md
@@ -13,7 +13,7 @@
 In this exercise, you will learn how to create a cluster using kubeadm. The cluster will contain of a single control plane node named `kube-control-plane`, and a worker node named `kube-worker-1`. The existing setup uses virtual machines (VMs) to emulate the cluster environment.
 
 > [!NOTE]
-> The file [vagrant-setup.md](../common/vagrant-setup.md) describes the setup instructions and commands for Vagrant and VMware. If you do not want to use the Vagrant environment, you can use the O'Reilly interactive lab ["Installing a Kubernetes cluster"](https://learning.oreilly.com/scenarios/cka-prep-installing/9781492095507/).
+> The file [vagrant-setup.md](../common/vagrant-setup.md) describes the setup instructions and commands for Vagrant and VMware. If you do not want to use the Vagrant environment, you can use the O'Reilly interactive lab ["Installing a Cluster"](https://learning.oreilly.com/interactive-lab/cka-prep-installing/9781492095507/).
 
 ## Initializing the Control Plane Node
 

--- a/exercises/02-cluster-version-upgrade/instructions.md
+++ b/exercises/02-cluster-version-upgrade/instructions.md
@@ -13,7 +13,7 @@
 In this exercise, you will learn how to upgrade the cluster version from 1.31.1 to 1.31.5 using kubeadm. The cluster will contain of a single control plane node named `kube-control-plane`, and one worker node named `kube-worker-1`. The existing setup uses virtual machines (VMs) to emulate the cluster environment.
 
 > [!NOTE]
-> The file [vagrant-setup.md](../common/vagrant-setup.md) describes the setup instructions and commands for Vagrant and VMware. If you do not want to use the Vagrant environment, you can use the O'Reilly interactive lab ["Upgrading a cluster version"](https://learning.oreilly.com/interactive-lab/cka-prep-upgrading/9781492095514).
+> The file [vagrant-setup.md](../common/vagrant-setup.md) describes the setup instructions and commands for Vagrant and VMware. If you do not want to use the Vagrant environment, you can use the O'Reilly interactive lab ["Upgrading a Cluster Version"](https://learning.oreilly.com/interactive-lab/cka-prep-upgrading/9781492095514/).
 
 ## Upgrading the Control Plane Node
 

--- a/exercises/03-etcd-backup-restore/instructions.md
+++ b/exercises/03-etcd-backup-restore/instructions.md
@@ -13,7 +13,7 @@
 In this exercise, you will identify the configuration of the etcd database, back it up and restore the original database from a backup file. The command line tools `etcdctl` and `etcdutl` have already been pre-installed on the control plane node.
 
 > [!NOTE]
-> The file [vagrant-setup.md](../common/vagrant-setup.md) describes the setup instructions and commands for Vagrant and VMware. If you do not want to use the Vagrant environment, you can use the O'Reilly interactive lab ["Backing up and restoring etcd"](https://learning.oreilly.com/scenarios/cka-prep-backing/9781492095521/).
+> The file [vagrant-setup.md](../common/vagrant-setup.md) describes the setup instructions and commands for Vagrant and VMware. If you do not want to use the Vagrant environment, you can use the O'Reilly interactive lab ["Backing Up and Restoring Etcd"](https://learning.oreilly.com/interactive-lab/cka-prep-backing/9781492095521/).
 
 1. Shell into control plane node using the command `vagrant ssh kube-control-plane`.
 2. Check that all nodes have been correctly registered and are in the "Ready" status.

--- a/exercises/04-rbac/instructions.md
+++ b/exercises/04-rbac/instructions.md
@@ -17,7 +17,7 @@ The following image shows the high-level architecture.
 ![rbac](imgs/rbac.png)
 
 > [!NOTE]
-> If you do not already have a cluster, you can create one by using minikube or you can use the O'Reilly interactive lab ["Setting up RBAC for a user"](https://learning.oreilly.com/scenarios/cka-prep-setting/9781492095477/).
+> If you do not already have a cluster, you can create one by using minikube or you can use the O'Reilly interactive lab ["Setting Up RBAC for a User"](https://learning.oreilly.com/interactive-lab/cka-prep-setting/9781492095477/).
 
 ## Creating the User
 

--- a/exercises/18-persistent-volume/dynamic-binding/instructions.md
+++ b/exercises/18-persistent-volume/dynamic-binding/instructions.md
@@ -13,7 +13,7 @@
 In this exercise, you will create a PersistentVolume using dynamic binding and mount it to a Pod.
 
 > [!NOTE]
-> If you do not already have a cluster, you can create one by using minikube or you can use the O'Reilly interactive lab ["Creating a PersistentVolume via dynamic binding"](https://learning.oreilly.com/scenarios/cka-prep-creating/9781492099161/).
+> If you do not already have a cluster, you can create one by using minikube or you can use the O'Reilly interactive lab ["Creating a PersistentVolume via Dynamic Binding"](https://learning.oreilly.com/interactive-lab/cka-prep-creating/9781492099161/).
 
 1. List all the storage class objects in the `default` namespace.
 2. If you are trying out dynamic binding, then create a new storage class with appropriate settings for your Kubernetes environment. Name the storage class object `custom`. On Minikube, use the provisioner `k8s.io/minikube-hostpath`. Assign the annotation `storageclass.beta.kubernetes.io/is-default-class: "false"` and the label `addonmanager.kubernetes.io/mode: Reconcile`.

--- a/exercises/25-troubleshooting-control-plane/instructions.md
+++ b/exercises/25-troubleshooting-control-plane/instructions.md
@@ -13,7 +13,7 @@
 In this exercise, you will learn how to troubleshooting the underlying issue of a Deployment not being able to schedule its Pods. The cluster will contain of a single control plane node named `kube-control-plane`, and one worker node named `kube-worker-1`. The existing setup uses virtual machines (VMs) to emulate the cluster environment.
 
 > [!NOTE]
-> The file [vagrant-setup.md](../common/vagrant-setup.md) describes the setup instructions and commands for Vagrant and VMware. If you do not want to use the Vagrant environment, you can use the O'Reilly interactive lab ["Troubleshooting a control plane node"](https://learning.oreilly.com/scenarios/cka-prep-troubleshooting/9781492099215/).
+> The file [vagrant-setup.md](../common/vagrant-setup.md) describes the setup instructions and commands for Vagrant and VMware. If you do not want to use the Vagrant environment, you can use the O'Reilly interactive lab ["Troubleshooting a Control Plane Node"](https://learning.oreilly.com/interactive-lab/cka-prep-troubleshooting/9781492099215/).
 
 1. Check the status of the Deployment named `deploy` and its Pods. How many Pods have been scheduled?
 2. Check the events of any of the Pods.

--- a/exercises/26-troubleshooting-worker-node/instructions.md
+++ b/exercises/26-troubleshooting-worker-node/instructions.md
@@ -13,7 +13,7 @@
 In this exercise, you will learn how to troubleshooting the underlying issue of worker node. The cluster will contain of a single control plane node named `kube-control-plane`, and one worker node named `kube-worker-1`. The existing setup uses virtual machines (VMs) to emulate the cluster environment.
 
 > [!NOTE]
-> The file [vagrant-setup.md](../common/vagrant-setup.md) describes the setup instructions and commands for Vagrant and VMware. If you do not want to use the Vagrant environment, you can use the O'Reilly interactive lab ["Troubleshooting a worker node"](https://learning.oreilly.com/scenarios/cka-prep-troubleshooting/9781492099222/).
+> The file [vagrant-setup.md](../common/vagrant-setup.md) describes the setup instructions and commands for Vagrant and VMware. If you do not want to use the Vagrant environment, you can use the O'Reilly interactive lab ["Troubleshooting a Worker Node"](https://learning.oreilly.com/interactive-lab/cka-prep-troubleshooting/9781492099222/).
 
 1. Check the status of the nodes. Do you see an issue?
 2. Shell into the node having an issue and identify the root cause.

--- a/exercises/28-extra-troubleshooting-app/instructions.md
+++ b/exercises/28-extra-troubleshooting-app/instructions.md
@@ -17,7 +17,7 @@ The following image shows the high-level architecture.
 ![app-architecture](imgs/app-architecture.png)
 
 > [!NOTE]
-> If you do not already have a cluster, you can create one by using minikube or you can use the O'Reilly interactive lab ["Troubleshooting a Deployment"](https://learning.oreilly.com/scenarios/cka-prep-troubleshooting/9781492099192/).
+> If you do not already have a cluster, you can create one by using minikube or you can use the O'Reilly interactive lab ["Troubleshooting a Deployment"](https://learning.oreilly.com/interactive-lab/cka-prep-troubleshooting/9781492099192/).
 
 ## Fixing the issue in namespace "gemini"
 


### PR DESCRIPTION
## Summary
- Updated O'Reilly lab URL paths from `/scenarios/` to `/interactive-lab/` (canonical path) across 8 exercise files
- Fixed lab title capitalization to match the O'Reilly platform (e.g., "Troubleshooting a worker node" → "Troubleshooting a Worker Node")
- Ensured consistent trailing slashes on all URLs