### PR TITLE
Update Kubernetes version to 1.34.6

### DIFF
--- a/.github/workflows/validate-manifests.yml
+++ b/.github/workflows/validate-manifests.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Set up Kubeconform
         uses: bmuschko/setup-kubeconform@v1
       - name: Validate Against Kubernetes Schema
-        run: kubeconform -kubernetes-version=1.34.2 -schema-location default -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' -ignore-filename-pattern=.github/workflows -ignore-filename-pattern=.json$ -summary .
+        run: kubeconform -kubernetes-version=1.34.6 -schema-location default -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' -ignore-filename-pattern=.github/workflows -ignore-filename-pattern=.json$ -summary .


### PR DESCRIPTION
## Summary
- Updates the kubeconform Kubernetes schema version from 1.34.2 to 1.34.6 in the GitHub Actions manifest validation workflow
- Aligns with the latest patch release of v1.34, which is the current CKA exam version
